### PR TITLE
Add EEPROM to device tree 

### DIFF
--- a/boards/ZCU111/petalinux_bsp/meta-user/recipes-bsp/device-tree/files/system-user.dtsi
+++ b/boards/ZCU111/petalinux_bsp/meta-user/recipes-bsp/device-tree/files/system-user.dtsi
@@ -1,5 +1,8 @@
 /include/ "system-conf.dtsi"
-/ {
+/ { 
+	chosen {
+		xlnx,eeprom = &eeprom;
+	};
 	amba_pl@0 {
 		data_source_top0:data_source_top@a0000000 {
 			compatible = "xlnx,data-source-top-1.0";
@@ -10,6 +13,15 @@
 
 &i2c1 {
 	i2c-mux@74 { /* u26 */
+		i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+				eeprom: eeprom@54 { /* u88 */
+					compatible = "atmel,24c08";
+					reg = <0x54>;
+					};
+		};
 		i2c@5 {
 			#address-cells = <1>;
 			#size-cells = <0>;


### PR DESCRIPTION
**ORIGINAL ISSUE**: The latest SD card image for ZCU111 (PYNQ 3.0.1) does not use EEPROM to get MAC address. Instead it gets assigned randomly during boot.

**ABOUT THIS PR**:  EEPROM is included into device tree and MAC is read from it during u-boot
Verified by rebuilding .img on Ubuntu 18.04.4 LTS.